### PR TITLE
feat(#71): attribute reading/writing for medit format + tests

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -7,9 +7,10 @@ jobs:
   linux-mac:
     strategy:
       matrix:
-        cfg: [{os: ubuntu-latest, cxx: g++-12},
-              {os: ubuntu-latest, cxx: g++-9},
-              {os: macos-latest, cxx: clang++}]
+        cfg: [{os: ubuntu-latest, cxx: g++},
+              # {os: ubuntu-latest, cxx: g++-9},
+              # get clang 16 ! because we need C++20 support
+              {os: macos-latest, cxx: /opt/homebrew/opt/llvm@16/bin/clang++}] 
         config: [Release, Debug]
 
     runs-on:  ${{ matrix.cfg.os }}
@@ -22,6 +23,11 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Install Clang 16 (macOS)
+      if: matrix.cfg.os == 'macos-latest'
+      run: |
+        brew install llvm@16
+
     - name: Configure CMake
       run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DUM_UNIT_TESTS=ON
 
@@ -30,7 +36,6 @@ jobs:
 
     - name: CTest
       run: ctest --test-dir build -V
-
 
   windows-msvc:
     runs-on: windows-latest

--- a/tests/test-geom.cpp
+++ b/tests/test-geom.cpp
@@ -92,13 +92,14 @@ TEST_CASE("aggregate", "[geom]") {
 	// CHECK(std::is_aggregate<Hexahedron>());
 	// CHECK(std::is_aggregate<Pyramid>());
 
-	// CHECK(std::is_aggregate<vec2>());
+	CHECK(std::is_aggregate<vec2>());
+	CHECK(std::is_aggregate<vec3>());
 }
 
 // TEST_CASE("vec benchmark", "[geom]") {
 
 //     auto start = std::chrono::high_resolution_clock::now();
-// 	for (int i = 0; i < 100000000; i++) {
+// 	for (int i = 0; i < 1000000000; i++) {
 // 		vec2 v{rand()%100, rand()%100};
 // 	}
 //     // Capture the end time
@@ -108,12 +109,6 @@ TEST_CASE("aggregate", "[geom]") {
 //     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
 
 //     // Output the duration
-//     INFO("DURATION: " << duration.count() << " milliseconds");
-//     INFO("DURATION: " << duration.count() << " milliseconds");
-//     INFO("DURATION: " << duration.count() << " milliseconds");
-//     INFO("DURATION: " << duration.count() << " milliseconds");
-//     INFO("DURATION: " << duration.count() << " milliseconds");
-//     INFO("DURATION: " << duration.count() << " milliseconds");
 //     INFO("DURATION: " << duration.count() << " milliseconds");
 // 	CHECK(false);
 // }

--- a/tests/test-io-medit.cpp
+++ b/tests/test-io-medit.cpp
@@ -17,13 +17,13 @@ Dimension
 Vertices
 3
 0. 0.9 0. 0
-0. 0.8 0. 0
-1. 0.3 0. 0
+0. 0.8 0. 1
+1. 0.3 0. 4
 
 End
 )";
 
-TEST_CASE("Medit PointSet IO test", "[Medit]") {
+TEST_CASE("Medit PointSet + PointSetAttributes IO test", "[Medit]") {
     static const std::string filename[2] = { "ultimaille-test-pointset-in.mesh", "ultimaille-test-pointset-out.mesh" };
     std::ofstream ofs(filename[0], std::ios::binary);
     ofs << points_str;
@@ -31,11 +31,19 @@ TEST_CASE("Medit PointSet IO test", "[Medit]") {
 
     PointSet m[2] = {};
     for (int i : range(2)) {
-        read_by_extension(filename[i], m[i]);
+        PointSetAttributes attrs = read_by_extension(filename[i], m[i]);
+        PointAttribute<int> vint("region", attrs, m[i]);
+        
+        const int n_verts = m[i].size();
 
-        REQUIRE( m[i].size()==3 );
+        REQUIRE( n_verts==3 );
+
+        for (int v = 0; v < n_verts; v++) {
+            CHECK(vint[v]==v*v);
+        }
+
         if (!i)
-            write_by_extension(filename[1], m[0]);
+            write_by_extension(filename[1], m[0], {{{"region", vint.ptr}}});
     }
 }
 
@@ -48,13 +56,13 @@ Dimension
 Vertices
 3
 0. 0.9 0. 0
-0. 0.8 0. 0
-1. 0.3 0. 0
+0. 0.8 0. 1
+1. 0.3 0. 4
 
 Edges
 2
 1 2 0
-2 3 0
+2 3 1
 
 End
 )";
@@ -67,12 +75,23 @@ TEST_CASE("Medit Polyline IO test", "[Medit]") {
 
     PolyLine m[2] = {};
     for (int i : range(2)) {
-        read_by_extension(filename[i], m[i]);
+        PolyLineAttributes attrs = read_by_extension(filename[i], m[i]);
+        PointAttribute<int> vint("region", attrs, m[i]);
+        EdgeAttribute<int> eint("region", attrs, m[i]);
 
         REQUIRE( m[i].nverts()==3 );
         REQUIRE( m[i].nedges()==2 );
+
+        for (auto v : m[i].iter_vertices()) {
+            CHECK(vint[v]==v*v);
+        }
+
+        for (auto e : m[i].iter_edges()) {
+            CHECK(eint[e]==e*e);
+        }
+
         if (!i)
-            write_by_extension(filename[1], m[0]);
+            write_by_extension(filename[1], m[0], {{{"region", vint.ptr}}, {{"region", eint.ptr}}});
     }
 }
 
@@ -84,13 +103,13 @@ Dimension
 
 Vertices
 3
-0. 0. 0. 1
+0. 0. 0. 0
 1. 0. 0. 1
-0. 1. 0. 1
+0. 1. 0. 4
 
 Triangles
 1
-1 2 3 1
+1 2 3 0
 
 End
 )";
@@ -103,14 +122,25 @@ TEST_CASE("Medit Triangles IO test", "[Medit]") {
 
     Triangles m[2] = {};
     for (int i : range(2)) {
-        read_by_extension(filename[i], m[i]);
+        SurfaceAttributes attrs = read_by_extension(filename[i], m[i]);
+        PointAttribute<int> vint("region", attrs, m[i]);
+        FacetAttribute<int> fint("region", attrs, m[i]);
 
         REQUIRE( m[i].nverts()==3 );
         REQUIRE( m[i].nfacets()==1 );
 
+        for (auto v : m[i].iter_vertices()) {
+            CHECK(vint[v]==v*v);
+        }
+
+        for (auto f : m[i].iter_facets()) {
+            CHECK(fint[f]==f*f);
+        }
+
+
         CHECK( std::abs(Surface::Facet(m[i], 0).geom<Triangle3>().unsigned_area()-.5)<ftol );
         if (!i)
-            write_by_extension(filename[1], m[0]);
+            write_by_extension(filename[1], m[0], {{{"region", vint.ptr}}, {{"region", fint.ptr}}, {}});
     }
 }
 
@@ -122,14 +152,14 @@ Dimension
 
 Vertices
 4
-0. 0. 0. 1
+0. 0. 0. 0
 1. 0. 0. 1
-1. 1. 0. 1
-0. 1. 0. 1
+1. 1. 0. 4
+0. 1. 0. 9
 
 Quadrilaterals
 1
-1 2 3 4  1
+1 2 3 4  0
 
 End
 )";
@@ -142,13 +172,24 @@ TEST_CASE("Medit Quads IO test", "[Medit]") {
 
     Quads m[2] = {};
     for (int i : range(2)) {
-        read_by_extension(filename[i], m[i]);
+        SurfaceAttributes attrs = read_by_extension(filename[i], m[i]);
+        PointAttribute<int> vint("region", attrs, m[i]);
+        FacetAttribute<int> fint("region", attrs, m[i]);
 
         REQUIRE( m[i].nverts()==4 );
         REQUIRE( m[i].nfacets()==1 );
+
+        for (auto v : m[i].iter_vertices()) {
+            CHECK(vint[v]==v*v);
+        }
+
+        for (auto f : m[i].iter_facets()) {
+            CHECK(fint[f]==f*f);
+        }
+
         CHECK( std::abs(Surface::Facet(m[i], 0).geom<Quad3>().unsigned_area()-1.)<ftol );
         if (!i)
-            write_by_extension(filename[1], m[0]);
+            write_by_extension(filename[1], m[0], {{{"region", vint.ptr}}, {{"region", fint.ptr}}, {}});
     }
 }
 
@@ -161,10 +202,10 @@ Dimension
 Vertices
 5
  1         0        0 0
- 0.309017  0.951057 0 0
--0.809017  0.587785 0 0
--0.809017 -0.587785 0 0
- 0.309017 -0.951057 0 0
+ 0.309017  0.951057 0 1
+-0.809017  0.587785 0 4
+-0.809017 -0.587785 0 9
+ 0.309017 -0.951057 0 16
 
 Triangles
 1
@@ -172,7 +213,7 @@ Triangles
 
 Quadrilaterals
 1
-4 5 1 3 0
+4 5 1 3 1
 
 End
 )";
@@ -185,14 +226,25 @@ TEST_CASE("Medit poly IO test", "[Polygons]") {
 
     Polygons m[2] = {};
     for (int i : range(2)) {
-        read_by_extension(filename[i], m[i]);
+        SurfaceAttributes attrs = read_by_extension(filename[i], m[i]);
+        PointAttribute<int> vint("region", attrs, m[i]);
+        FacetAttribute<int> fint("region", attrs, m[i]);
 
         REQUIRE( m[i].nverts()==5 );
         REQUIRE( m[i].nfacets()==2 );
         REQUIRE( m[i].facet_size(0)==3 );
         REQUIRE( m[i].facet_size(1)==4 );
+
+        for (auto v : m[i].iter_vertices()) {
+            CHECK(vint[v]==v*v);
+        }
+
+        for (auto f : m[i].iter_facets()) {
+            CHECK(fint[f]==f*f);
+        }
+
         if (!i)
-            write_by_extension(filename[1], m[0]);
+            write_by_extension(filename[1], m[0], {{{"region", vint.ptr}}, {{"region", fint.ptr}}, {}});
     }
 }
 
@@ -203,15 +255,17 @@ Dimension
 3
 
 Vertices
-4
-0. 0. 0. 1
+5
+0. 0. 0. 0
 1. 0. 0. 1
-0. 1. 0. 1
-0. 1. 1. 1
+0. 1. 0. 4
+0. 1. 1. 9
+0. 0. 1. 16
 
 Tetrahedra
-1
-1 2 3 4 1
+2
+1 2 3 4 0
+1 3 4 5 1
 
 End
 )";
@@ -224,13 +278,31 @@ TEST_CASE("Medit Tetrahedra IO test", "[Medit]") {
 
     Tetrahedra m[2] = {};
     for (int i : range(2)) {
-        read_by_extension(filename[i], m[i]);
+        VolumeAttributes attrs = read_by_extension(filename[i], m[i]);
+        PointAttribute<int> vint("region", attrs, m[i]);
+        CellFacetAttribute<int> fint("region", attrs, m[i]);
+        CellAttribute<int> cint("region", attrs, m[i]);
 
-        REQUIRE( m[i].nverts()==4 );
-        REQUIRE( m[i].ncells()==1 );
+        REQUIRE( m[i].nverts()==5 );
+        REQUIRE( m[i].ncells()==2 );
         CHECK( std::abs(Volume::Cell(m[i], 0).geom<Tetrahedron>().volume()-1./6.)<ftol );
+
+        for (auto v : m[i].iter_vertices()) {
+            CHECK(vint[v]==v*v);
+        }
+
+        // Not any facet explicitly defined nor facet attribute
+        // attribute should be equal to 0
+        for (auto f : m[i].iter_facets()) {
+            CHECK(fint[f]==0);
+        }
+
+        for (auto c : m[i].iter_cells()) {
+            CHECK(cint[c]==c*c);
+        }
+
         if (!i)
-            write_by_extension(filename[1], m[0]);
+            write_by_extension(filename[1], m[0], {{{"region", vint.ptr}}, {{"region", cint.ptr}}, {{"region", fint.ptr}}, {}});
     }
 }
 
@@ -242,18 +314,18 @@ Dimension
 
 Vertices
 8
-0. 0. 0. 1
+0. 0. 0. 0
 1. 0. 0. 1
-1. 1. 0. 1
-0. 1. 0. 1
-0. 0. 1. 1
-1. 0. 1. 1
-1. 1. 1. 1
-0. 1. 1. 1
+1. 1. 0. 4
+0. 1. 0. 9
+0. 0. 1. 16
+1. 0. 1. 25
+1. 1. 1. 36
+0. 1. 1. 49
 
 Hexahedra
 1
-1 2 3 4 5 6 7 8 1
+1 2 3 4 5 6 7 8 42
 
 End
 )";
@@ -266,13 +338,24 @@ TEST_CASE("Medit Hexahedra IO test", "[Medit]") {
 
     Hexahedra m[2] = {};
     for (int i : range(2)) {
-        read_by_extension(filename[i], m[i]);
+        VolumeAttributes attrs = read_by_extension(filename[i], m[i]);
+        PointAttribute<int> vint("region", attrs, m[i]);
+        CellAttribute<int> cint("region", attrs, m[i]);
 
         REQUIRE( m[i].nverts()==8 );
         REQUIRE( m[i].ncells()==1 );
         CHECK( std::abs(Volume::Cell(m[i], 0).geom<Hexahedron>().volume()-1.)<ftol );
+
+        for (auto v : m[i].iter_vertices()) {
+            CHECK(vint[v]==v*v);
+        }
+
+        for (auto c : m[i].iter_cells()) {
+            CHECK(cint[c]==42);
+        }
+
         if (!i)
-            write_by_extension(filename[1], m[0]);
+            write_by_extension(filename[1], m[0], {{{"region", vint.ptr}}, {{"region", cint.ptr}}, {}, {}});
     }
 }
 
@@ -284,16 +367,16 @@ Dimension
 
 Vertices
 6
-0. 0. 0. 1
+0. 0. 0. 0
 1. 0. 0. 1
-0. 1. 0. 1
-0. 0. 1. 1
-1. 0. 1. 1
-0. 1. 1. 1
+0. 1. 0. 4
+0. 0. 1. 9
+1. 0. 1. 16
+0. 1. 1. 25
 
 Prisms
 1
-1 2 3 4 5 6 1
+1 2 3 4 5 6 42
 
 End
 )";
@@ -306,13 +389,24 @@ TEST_CASE("Medit Wedges IO test", "[Medit]") {
 
     Wedges m[2] = {};
     for (int i : range(2)) {
-        read_by_extension(filename[i], m[i]);
+        VolumeAttributes attrs = read_by_extension(filename[i], m[i]);
+        PointAttribute<int> vint("region", attrs, m[i]);
+        CellAttribute<int> cint("region", attrs, m[i]);
 
         REQUIRE( m[i].nverts()==6 );
         REQUIRE( m[i].ncells()==1 );
         CHECK( std::abs(Volume::Cell(m[i], 0).geom<Wedge>().volume()-.5)<ftol );
+
+        for (auto v : m[i].iter_vertices()) {
+            CHECK(vint[v]==v*v);
+        }
+
+        for (auto c : m[i].iter_cells()) {
+            CHECK(cint[c]==42);
+        }
+
         if (!i)
-            write_by_extension(filename[1], m[0]);
+            write_by_extension(filename[1], m[0], {{{"region", vint.ptr}}, {{"region", cint.ptr}}, {}, {}});
     }
 }
 
@@ -324,15 +418,15 @@ Dimension
 
 Vertices
 5
-0.  0.  0.  1
+0.  0.  0.  0
 1.  0.  0.  1
-1.  1.  0.  1
-0.  1.  0.  1
-0.5 0.5 0.5 1
+1.  1.  0.  4
+0.  1.  0.  9
+0.5 0.5 0.5 16
 
 Pyramids
 1
-1 2 3 4 5 1
+1 2 3 4 5 42
 
 End
 )";
@@ -345,13 +439,24 @@ TEST_CASE("Medit Pyramids IO test", "[Medit]") {
 
     Pyramids m[2] = {};
     for (int i : range(2)) {
-        read_by_extension(filename[i], m[i]);
+        VolumeAttributes attrs = read_by_extension(filename[i], m[i]);
+        PointAttribute<int> vint("region", attrs, m[i]);
+        CellAttribute<int> cint("region", attrs, m[i]);
 
         REQUIRE( m[i].nverts()==5 );
         REQUIRE( m[i].ncells()==1 );
         CHECK( std::abs(Volume::Cell(m[i], 0).geom<Pyramid>().volume()-1./6.)<ftol );
+
+        for (auto v : m[i].iter_vertices()) {
+            CHECK(vint[v]==v*v);
+        }
+
+        for (auto c : m[i].iter_cells()) {
+            CHECK(cint[c]==42);
+        }
+
         if (!i)
-            write_by_extension(filename[1], m[0]);
+            write_by_extension(filename[1], m[0], {{{"region", vint.ptr}}, {{"region", cint.ptr}}, {}, {}});
     }
 }
 

--- a/ultimaille/algebra/vec.h
+++ b/ultimaille/algebra/vec.h
@@ -96,8 +96,8 @@ namespace UM {
     template<> struct vec<3>;
 
     template<> struct vec<2> {
-        vec() =  default;
-        constexpr vec(double X, double Y) : x(X), y(Y) {}
+        // vec() =  default;
+        // constexpr vec(double X, double Y) : x(X), y(Y) {}
         double& operator[](const int i)       { assert(i>=0 && i<2); return i==0 ? x : y; }
         double  operator[](const int i) const { assert(i>=0 && i<2); return i==0 ? x : y; }
         double norm2() const { return (*this)*(*this) ; }
@@ -113,8 +113,8 @@ namespace UM {
     /////////////////////////////////////////////////////////////////////////////////
 
     template<> struct vec<3> {
-        vec() = default;
-        constexpr vec(double X, double Y, double Z) : x(X), y(Y), z(Z) {}
+        // vec() = default;
+        // constexpr vec(double X, double Y, double Z) : x(X), y(Y), z(Z) {}
         double& operator[](const int i)       { assert(i>=0 && i<3); return i==0 ? x : (1==i ? y : z); }
         double  operator[](const int i) const { assert(i>=0 && i<3); return i==0 ? x : (1==i ? y : z); }
         double norm2() const { return (*this)*(*this) ; }

--- a/ultimaille/io/by_extension.h
+++ b/ultimaille/io/by_extension.h
@@ -24,7 +24,7 @@ namespace UM {
             if (ext == ".geogram")
                 write_geogram(path, m, a);
             if (ext == ".mesh")
-                write_medit(path, m);
+                write_medit(path, m, a);
             if (ext == ".vtk")
                 write_vtk(path, m, a);
             if constexpr (std::is_same_v<decltype(empty_attr(m)), PointSetAttributes>) {

--- a/ultimaille/io/medit.cpp
+++ b/ultimaille/io/medit.cpp
@@ -28,13 +28,23 @@ namespace UM {
         return (std::string(copy_without_space.begin(), copy_without_space.begin() + (long int)start_of_string.size()) == start_of_string);
     }
 
-    void read_medit_format(const std::string& filename, std::vector<int>& vcolors_, std::vector<vec3>& verts_, std::vector<int>& edges_, std::vector<int>& tris_, std::vector<int>& quads_, std::vector<int>& tets_, std::vector<int>& hexes_, std::vector<int>& wedges_, std::vector<int>& pyramids_) {
+    const std::string attrib_set_names[4] = {"GEO::Mesh::vertices", "GEO::Mesh::edges", "GEO::Mesh::facets", "GEO::Mesh::cells"};
+
+    void read_medit_format(const std::string& filename, std::vector<vec3>& verts_, std::vector<int>& edges_, std::vector<int>& tris_, std::vector<int>& quads_, std::vector<int>& tets_, std::vector<int>& hexes_, std::vector<int>& wedges_, std::vector<int>& pyramids_, std::vector<NamedContainer> attr[4]) {
         std::ifstream in;
         in.open(filename, std::ifstream::in);
         if (in.fail())
             throw std::runtime_error("Failed to open " + filename);
 
+        const char attr_name[] = "region";
+
         std::string firstline;
+
+        int nb_of_tri = 0, nb_of_quads = 0;
+        std::vector<int> facet_region;
+
+        int nb_of_tets = 0, nb_of_hexs = 0, nb_of_prisms = 0, nb_of_pyramids = 0;
+        std::vector<int> cell_region;
 
         while (!in.eof()) {
             std::getline(in, firstline);
@@ -47,15 +57,19 @@ namespace UM {
                     std::istringstream iss(line.c_str());
                     iss >> nb_of_vertices;
                 }
+
+                // Create vertices region attribute
+                GenericAttribute<int> vertices_region(nb_of_vertices);
+
                 verts_.resize(nb_of_vertices);
-                vcolors_.resize(nb_of_vertices);
                 FOR(v, nb_of_vertices) {
                     file_must_no_be_at_end(in, "parsing vertices");
                     std::getline(in, line);
                     std::istringstream iss(line.c_str());
                     FOR(i, 3)  iss >> verts_[v][i];
-                    iss >> vcolors_[v];
+                    iss >> vertices_region[v];
                 }
+                attr[0].emplace_back(attr_name, vertices_region.ptr);
             }
             if (string_start(firstline, "Edges")) {
                 std::string line;
@@ -66,6 +80,10 @@ namespace UM {
                     std::istringstream iss(line.c_str());
                     iss >> nb_of_edges;
                 }
+
+                // Create edges region attribute
+                GenericAttribute<int> edges_region(nb_of_edges);
+
                 edges_.resize(2 * nb_of_edges);
                 FOR(e, nb_of_edges) {
                     file_must_no_be_at_end(in, "parsing Edges");
@@ -76,17 +94,22 @@ namespace UM {
                         iss >> a;
                         edges_[2 * e + i] = a - 1;
                     }
+                    iss >> edges_region[e];
                 }
-            }
+                attr[1].emplace_back(attr_name, edges_region.ptr);
+            }           
+
             if (string_start(firstline, "Triangles")) {
                 std::string line;
-                int nb_of_tri = 0;
                 {
                     file_must_no_be_at_end(in, "parsing Triangles");
                     std::getline(in, line);
                     std::istringstream iss(line.c_str());
                     iss >> nb_of_tri;
                 }
+                
+                facet_region.resize(nb_of_tri + nb_of_quads);
+
                 tris_.resize(3 * nb_of_tri);
                 FOR(t, nb_of_tri) {
                     file_must_no_be_at_end(in, "parsing Triangles");
@@ -97,17 +120,20 @@ namespace UM {
                         iss >> a;
                         tris_[3 * t + i] = a - 1;
                     }
+                    iss >> facet_region[t];
                 }
             }
             if (string_start(firstline, "Quadrilaterals")) {
                 std::string line;
-                int nb_of_quads = 0;
                 {
                     file_must_no_be_at_end(in, "parsing Quadrilaterals");
                     std::getline(in, line);
                     std::istringstream iss(line.c_str());
                     iss >> nb_of_quads;
                 }
+
+                facet_region.resize(nb_of_tri + nb_of_quads);
+
                 quads_.resize(4 * nb_of_quads);
                 FOR(q, nb_of_quads) {
                     file_must_no_be_at_end(in, "parsing Quadrilaterals");
@@ -118,17 +144,21 @@ namespace UM {
                         iss >> a;
                         quads_[4 * q + i] = a - 1;
                     }
+                    iss >> facet_region[nb_of_tri + q];
                 }
             }
+
             if (string_start(firstline, "Tetrahedra")) {
                 std::string line;
-                int nb_of_tets = 0;
                 {
                     file_must_no_be_at_end(in, "parsing Tetrahedra");
                     std::getline(in, line);
                     std::istringstream iss(line.c_str());
                     iss >> nb_of_tets;
                 }
+
+                cell_region.resize(nb_of_tets + nb_of_hexs + nb_of_prisms + nb_of_pyramids);
+
                 tets_.resize(4 * nb_of_tets);
                 FOR(t, nb_of_tets) {
                     file_must_no_be_at_end(in, "parsing Tetrahedra");
@@ -139,17 +169,20 @@ namespace UM {
                         iss >> a;
                         tets_[4 * t + i] = a - 1;
                     }
+                    iss >> cell_region[t];
                 }
             }
             if (string_start(firstline, "Hexahedra")) {
                 std::string line;
-                int nb_of_hexs = 0;
                 {
                     file_must_no_be_at_end(in, "parsing Hexahedra");
                     std::getline(in, line);
                     std::istringstream iss(line.c_str());
                     iss >> nb_of_hexs;
                 }
+
+                cell_region.resize(nb_of_tets + nb_of_hexs + nb_of_prisms + nb_of_pyramids);
+                
                 hexes_.resize(8 * nb_of_hexs);
                 FOR(h, nb_of_hexs) {
                     file_must_no_be_at_end(in, "parsing Hexahedra");
@@ -160,17 +193,20 @@ namespace UM {
                         iss >> a;
                         hexes_[8 * h + hex_medit2geogram[i]] = a - 1;
                     }
+                    iss >> cell_region[nb_of_tets + h];
                 }
             }
             if (string_start(firstline, "Prisms")) {
                 std::string line;
-                int nb_of_prisms = 0;
                 {
                     file_must_no_be_at_end(in, "parsing Prisms");
                     std::getline(in, line);
                     std::istringstream iss(line.c_str());
                     iss >> nb_of_prisms;
                 }
+
+                cell_region.resize(nb_of_tets + nb_of_hexs + nb_of_prisms + nb_of_pyramids);
+
                 wedges_.resize(6 * nb_of_prisms);
                 FOR(h, nb_of_prisms) {
                     file_must_no_be_at_end(in, "parsing Prisms");
@@ -181,17 +217,20 @@ namespace UM {
                         iss >> a;
                         wedges_[6 * h + i] = a - 1;
                     }
+                    iss >> cell_region[nb_of_tets + nb_of_hexs + h];
                 }
             }
             if (string_start(firstline, "Pyramids")) {
                 std::string line;
-                int nb_of_pyramids = 0;
                 {
                     file_must_no_be_at_end(in, "parsing Pyramids");
                     std::getline(in, line);
                     std::istringstream iss(line.c_str());
                     iss >> nb_of_pyramids;
                 }
+
+                cell_region.resize(nb_of_tets + nb_of_hexs + nb_of_prisms + nb_of_pyramids);
+
                 pyramids_.resize(5 * nb_of_pyramids);
                 FOR(h, nb_of_pyramids) {
                     file_must_no_be_at_end(in, "parsing Pyramids");
@@ -202,44 +241,86 @@ namespace UM {
                         iss >> a;
                         pyramids_[5 * h + i] = a - 1;
                     }
+                    iss >> cell_region[nb_of_tets + nb_of_hexs + nb_of_prisms + h];
                 }
             }
         }
+
+        // Create facet region attribute
+        const int nb_facets = nb_of_tri + nb_of_quads;
+        if (nb_facets > 0) {    
+            GenericAttribute<int> facet_region_attr(nb_facets);
+            for (int i = 0; i < facet_region.size(); i++) {
+                facet_region_attr[i] = facet_region[i];
+            }
+
+            attr[2].emplace_back(attr_name, facet_region_attr.ptr);
+        }
+        // Create cell region attribute
+        const int nb_cells = nb_of_tets + nb_of_hexs + nb_of_prisms + nb_of_pyramids;
+        if (nb_cells > 0) {    
+            GenericAttribute<int> cell_region_attr(nb_cells);
+            for (int i = 0; i < cell_region.size(); i++) {
+                cell_region_attr[i] = cell_region[i];
+            }
+
+            attr[3].emplace_back(attr_name, cell_region_attr.ptr);
+        }
+
     }
 
-    void write_medit_format(const std::string& filename, const std::vector<vec3>& verts_, const std::vector<int>& edges_, const std::vector<int>& tris_, const std::vector<int>& quads_, const std::vector<int>& tets_, const  std::vector<int>& hexes_, const std::vector<int>& wedges_, const  std::vector<int>& pyramids_) {
+    std::vector<int> load_attr(std::vector<NamedContainer> &container, int size) {
+        
+        if (container.size() <= 0) {
+            return std::move(std::vector<int>(size, 1));
+        }
+
+        std::shared_ptr<GenericAttributeContainer> point_attr_ptr = container[0].second;
+        if (auto point_cont_ptr = std::dynamic_pointer_cast<AttributeContainer<int>>(point_attr_ptr); point_cont_ptr.get()!=nullptr) {
+            return std::move(point_cont_ptr->data);
+        } else {
+            assert(false);
+        }
+    }
+
+    void write_medit_format(const std::string& filename, const std::vector<vec3>& verts_, const std::vector<int>& edges_, const std::vector<int>& tris_, const std::vector<int>& quads_, const std::vector<int>& tets_, const  std::vector<int>& hexes_, const std::vector<int>& wedges_, const  std::vector<int>& pyramids_, std::vector<NamedContainer> attr[4]) {
         std::ofstream out_f;
         out_f.open(filename, std::ifstream::out);
         if (out_f.fail())
             throw std::runtime_error("Failed to open " + filename);
         std::stringstream out;
         out << std::setprecision(std::numeric_limits<double>::max_digits10);
-//        out << std::fixed << std::setprecision(4);
         out << "MeshVersionFormatted 2" << std::endl << std::endl;
         out << "Dimension" << std::endl << "3" << std::endl << std::endl;
 
         out << "Vertices" << std::endl;
         out << verts_.size() << std::endl;
+        auto point_attr = load_attr(attr[0], verts_.size());
         FOR(v, verts_.size()) {
             FOR(d, 3) out << verts_[v][d] << " ";
-            out << "1" << std::endl;
+            out << point_attr[v] << std::endl;
         }
         out << std::endl;
         if (edges_.size() > 0) {
             out << "Edges" << std::endl;
             out << edges_.size() / 2 << std::endl;
+            auto edge_attr = load_attr(attr[1], edges_.size());
             FOR(e, edges_.size() / 2) {
                 FOR(i, 2) out << edges_[2 * e + i] + 1 << " ";
-                out << "1" << std::endl;
+                out << edge_attr[e] << std::endl;
             }
             out << std::endl << "End" << std::endl;
         }
+        
+        // Load facet attributes
+        auto facet_attr = load_attr(attr[2], tris_.size() / 3 + quads_.size() / 4);
+
         if (tris_.size() > 0) {
             out << "Triangles" << std::endl;
             out << tris_.size() / 3 << std::endl;
             FOR(t, tris_.size() / 3) {
                 FOR(i, 3) out << tris_[3 * t + i] + 1 << " ";
-                out << "1" << std::endl;
+                out << facet_attr[t] << std::endl;
             }
             out << std::endl << "End" << std::endl;
         }
@@ -248,46 +329,47 @@ namespace UM {
             out << quads_.size() / 4 << std::endl;
             FOR(q, quads_.size() / 4) {
                 FOR(i, 4) out << quads_[4 * q + i] + 1 << " ";
-                out << "1" << std::endl;
+                out << facet_attr[tris_.size() / 3 + q] << std::endl;
             }
             out << std::endl << "End" << std::endl;
         }
+
+        // Load cell attributes
+        auto cell_attr = load_attr(attr[3], tets_.size() / 4 + hexes_.size() / 8 + wedges_.size() / 6 + pyramids_.size() / 5);
+
         if (tets_.size() > 0) {
             out << "Tetrahedra" << std::endl;
             out << tets_.size() / 4 << std::endl;
             FOR(t, tets_.size() / 4) {
                 FOR(i, 4) out << tets_[4*t +i] + 1 << " ";
-                out << "1" << std::endl;
+                out << cell_attr[t] << std::endl;
             }
             out << std::endl << "End" << std::endl;
         }
-
         if (hexes_.size() > 0) {
             out << "Hexahedra" << std::endl;
             out << hexes_.size() / 8 << std::endl;
             FOR(h, hexes_.size() / 8) {
                 FOR(i, 8) out << hexes_[8 * h + hex_medit2geogram[i]] + 1 << " ";
-                out << "1" << std::endl;
+                out << cell_attr[tets_.size() / 4 + h] << std::endl;
             }
             out << std::endl << "End" << std::endl;
         }
-
         if (wedges_.size() > 0) {
             out << "Prisms" << std::endl;
             out << wedges_.size() / 6 << std::endl;
             FOR(h, wedges_.size() / 6) {
                 FOR(i, 6) out << wedges_[6 * h + i] + 1 << " ";
-                out << "1" << std::endl;
+                out << cell_attr[tets_.size() / 4 + hexes_.size() / 8 + h] << std::endl;
             }
             out << std::endl << "End" << std::endl;
         }
-
         if (pyramids_.size() > 0) {
             out << "Pyramids" << std::endl;
             out << pyramids_.size() / 5 << std::endl;
             FOR(h, pyramids_.size() / 5) {
                 FOR(i, 5) out << pyramids_[5 * h + i] + 1 << " ";
-                out << "1" << std::endl;
+                out << cell_attr[tets_.size() / 4 + hexes_.size() / 8 + wedges_.size() / 6 + h] << std::endl;
             }
             out << std::endl << "End" << std::endl;
         }
@@ -296,23 +378,25 @@ namespace UM {
         out_f.close();
     }
 
-    void write_medit(const std::string filename, const PointSet& ps) {
+    void write_medit(const std::string filename, const PointSet& ps, PointSetAttributes attr) {
         std::vector<vec3> verts(ps.size());
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
         FOR(v, ps.size()) verts[v] = ps[v];
-        write_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> A[4] = {attr.points, {}, {}, {}};
+        write_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, A);
     }
 
-    void write_medit(const std::string filename, const PolyLine& pl) {
+    void write_medit(const std::string filename, const PolyLine& pl, PolyLineAttributes attr) {
         std::vector<vec3> verts(pl.nverts());
         std::vector<int> edges(2 * pl.nedges());
         std::vector<int> tris, quads, tets, hexes, wedges, pyramids;
         FOR(v, pl.nverts()) verts[v] = pl.points[v];
         FOR(e, pl.nedges()) FOR(ev, 2) edges[2 * e + ev] = pl.vert(e, ev);
-        write_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> A[4] = {attr.points, attr.edges, {}, {}};
+        write_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, A);
     }
 
-    void write_medit(const std::string filename, const Surface& m) {
+    void write_medit(const std::string filename, const Surface& m, SurfaceAttributes attr) {
         std::vector<vec3> verts(m.nverts());
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
         FOR(v, m.nverts()) verts[v] = m.points[v];
@@ -326,10 +410,11 @@ namespace UM {
             else
                 std::cerr << "Warning: Polygons are not supported in our MEDIT writer";
         }
-        write_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> A[4] = {attr.points, {}, attr.facets, {}};
+        write_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, A);
     }
 
-    void write_medit(const std::string filename, const Volume& m) {
+    void write_medit(const std::string filename, const Volume& m, VolumeAttributes attr) {
         std::vector<vec3> verts(m.nverts());;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
         FOR(v, m.nverts()) verts[v] = m.points[v];
@@ -348,65 +433,66 @@ namespace UM {
         } else {
             std::cerr << "Warning: Volume type : " << m.cell_type << "; not supported in our MEDIT writer";
         }
-        write_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> A[4] = {attr.points, {}, attr.cell_facets, attr.cells};
+        write_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, A);
     }
 
 
     PointSetAttributes read_medit(const std::string filename, PointSet& m) {
         std::vector<vec3> verts;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
-        std::vector<int> vcolors;
-        read_medit_format(filename, vcolors, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> attrib[4];
+        read_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, attrib);
         m = PointSet();
         m.create_points(verts.size());
         FOR(v, verts.size()) m[v] = verts[v];
-        return {};
+        return {attrib[0]};
     }
 
     PolyLineAttributes read_medit(const std::string filename, PolyLine& m) {
         std::vector<vec3> verts;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
-        std::vector<int> vcolors;
-        read_medit_format(filename, vcolors, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> attrib[4];
+        read_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, attrib);
         m = PolyLine();
         m.points.create_points(verts.size());
         FOR(v, verts.size()) m.points[v] = verts[v];
         m.create_edges(edges.size()/2);
         FOR(e, m.nedges()) FOR(ev, 2) m.vert(e, ev) = edges[2 * e + ev];
-        return {};
+        return {attrib[0], attrib[1]};
     }
 
     SurfaceAttributes read_medit(const std::string filename, Triangles& m) {
         std::vector<vec3> verts;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
-        std::vector<int> vcolors;
-        read_medit_format(filename, vcolors, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> attrib[4];
+        read_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, attrib);
         m = Triangles();
         m.points.create_points(verts.size());
         FOR(v, verts.size()) m.points[v] = verts[v];
         m.create_facets(tris.size() / 3);
         FOR(t, m.nfacets()) FOR(tv, 3) m.vert(t, tv) = tris[3 * t + tv];
-        return {};
+        return {attrib[0], attrib[2], {}};
     }
 
     SurfaceAttributes read_medit(const std::string filename, Quads& m) {
         std::vector<vec3> verts;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
-        std::vector<int> vcolors;
-        read_medit_format(filename, vcolors, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> attrib[4];
+        read_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, attrib);
         m = Quads();
         m.points.create_points(verts.size());
         FOR(v, verts.size()) m.points[v] = verts[v];
         m.create_facets(quads.size() / 4);
         FOR(q, m.nfacets()) FOR(qv, 4) m.vert(q, qv) = quads[4 * q + qv];
-        return {};
+        return {attrib[0], attrib[2], {}};
     }
 
     SurfaceAttributes read_medit(const std::string filename, Polygons& m) {
         std::vector<vec3> verts;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
-        std::vector<int> vcolors;
-        read_medit_format(filename, vcolors, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> attrib[4];
+        read_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, attrib);
         m = Polygons();
         m.points.create_points(verts.size());
         FOR(v, verts.size()) m.points[v] = verts[v];
@@ -416,62 +502,63 @@ namespace UM {
 
         int off = m.create_facets(quads.size() / 4, 4);
         FOR(q, quads.size() / 4) FOR(qv, 4) m.vert(off + q, qv) = quads[4 * q + qv];
-        return {};
+        return {attrib[0], attrib[2], {}};
     }
 
     VolumeAttributes read_medit(const std::string filename, Tetrahedra& m) {
         std::vector<vec3> verts;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
-        std::vector<int> vcolors;
-        read_medit_format(filename, vcolors, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> attrib[4];
+        read_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, attrib);
         m = Tetrahedra();
         m.points.create_points(verts.size());
         FOR(v, verts.size()) m.points[v] = verts[v];
         m.create_cells(tets.size() / 4);
         FOR(t, m.ncells()) FOR(tv, 4) m.vert(t, tv) = tets[4 * t + tv];
-        return {};
+        return {attrib[0], attrib[3], attrib[2], {}};
     }
 
     VolumeAttributes read_medit(const std::string filename, Hexahedra& m) {
         std::vector<vec3> verts;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
-        std::vector<int> vcolors;
-        read_medit_format(filename, vcolors, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> attrib[4];
+        read_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, attrib);
         m = Hexahedra();
         m.points.create_points(verts.size());
         FOR(v, verts.size()) m.points[v] = verts[v];
 
         m.create_cells(hexes.size() / 8);
         FOR(h, m.ncells()) FOR(hv, 8) m.vert(h, hv) = hexes[8 * h + hv];
-        return {};
+        return {attrib[0], attrib[3], attrib[2], {}};
     }
 
     VolumeAttributes read_medit(const std::string filename, Wedges& m) {
         std::vector<vec3> verts;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
-        std::vector<int> vcolors;
-        read_medit_format(filename, vcolors, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> attrib[4];
+        read_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, attrib);
         m = Wedges();
         m.points.create_points(verts.size());
         FOR(v, verts.size()) m.points[v] = verts[v];
 
         m.create_cells(wedges.size() / 6);
         FOR(h, m.ncells()) FOR(hv, 6) m.vert(h, hv) = wedges[5 * h + hv];
-        return {};
+        return {attrib[0], attrib[3], attrib[2], {}};
     }
 
     VolumeAttributes read_medit(const std::string filename, Pyramids& m) {
         std::vector<vec3> verts;
         std::vector<int> edges, tris, quads, tets, hexes, wedges, pyramids;
-        std::vector<int> vcolors;
-        read_medit_format(filename, vcolors, verts, edges, tris, quads, tets, hexes, wedges, pyramids);
+        std::vector<NamedContainer> attrib[4];
+        read_medit_format(filename, verts, edges, tris, quads, tets, hexes, wedges, pyramids, attrib);
         m = Pyramids();
         m.points.create_points(verts.size());
         FOR(v, verts.size()) m.points[v] = verts[v];
 
         m.create_cells(pyramids.size() / 5);
         FOR(h, m.ncells()) FOR(hv, 5) m.vert(h, hv) = pyramids[5 * h + hv];
-        return {};
+
+        return {attrib[0], attrib[3], attrib[2], {}};
     }
 
 }

--- a/ultimaille/io/medit.h
+++ b/ultimaille/io/medit.h
@@ -26,10 +26,10 @@
  */
 
 namespace UM {
-    void write_medit(const std::string filename, const PointSet &ps);
-    void write_medit(const std::string filename, const PolyLine &pl);
-    void write_medit(const std::string filename, const Surface &m);
-    void write_medit(const std::string filename, const Volume  &m);
+    void write_medit(const std::string filename, const PointSet &ps, PointSetAttributes attr);
+    void write_medit(const std::string filename, const PolyLine &pl, PolyLineAttributes attr);
+    void write_medit(const std::string filename, const Surface &m, SurfaceAttributes attr);
+    void write_medit(const std::string filename, const Volume  &m, VolumeAttributes attr);
 
     PointSetAttributes read_medit(const std::string filename, PointSet   &m);
     PolyLineAttributes read_medit(const std::string filename, PolyLine   &m);


### PR DESCRIPTION
I've upgraded the read/write medit format in order to be able to load some attributes.
This format has some particularities, for example, if you want to read attributes from `Triangles` surface, we can access to `point` and `facet` attributes, however, i maintain the `corner` attribute of `SurfaceAttributes` empty as we don't read any corners in this format, although I believe it is possible to declare it...
I welcome any suggestions for making this code clearer.